### PR TITLE
Fix raw loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ As an added bonus, if you look at line forty-three (43) of `demo-advanced.mdx` t
 
 ```jsx
 <CodeSurfer
-  code={require("raw-loader!./snippets/example-dockerfile.snippet")}
+  code={require("!raw-loader!./snippets/example-dockerfile.snippet")}
   title="Dockerfile for photo-share-api"
   showNumbers
   steps={[

--- a/decks/functions/02-function-closure.mdx
+++ b/decks/functions/02-function-closure.mdx
@@ -26,7 +26,7 @@ import ReplIt from "../../components/replit";
 ---
 
 <CodeSurfer
-  code={require("raw-loader!./snippets/closure.snippet")}
+  code={require("!raw-loader!./snippets/closure.snippet")}
   theme={nightOwl}
   lang="javascript"
   title="Exploring Closures"

--- a/decks/promises/00-promises.mdx
+++ b/decks/promises/00-promises.mdx
@@ -94,7 +94,7 @@ specify and dispatch the request in one place:</p>
 ---
 
 <CodeSurfer
-  code={require("raw-loader!../../snippets/promises-1.snippet")}
+  code={require("!raw-loader!../../snippets/promises-1.snippet")}
   theme={nightOwl}
   lang="javascript"
   title="Fun with Promises"

--- a/decks/promises/01-promise-chain.mdx
+++ b/decks/promises/01-promise-chain.mdx
@@ -12,7 +12,7 @@ import ReplIt from "../../components/replit";
 
 ---
 <CodeSurfer
-  code={require("raw-loader!./snippets/promise-chain.snippet")}
+  code={require("!raw-loader!./snippets/promise-chain.snippet")}
   theme={nightOwl}
   lang="javascript"
   title="Promise Chains"
@@ -40,7 +40,7 @@ import ReplIt from "../../components/replit";
 
 ---
 <CodeSurfer
-  code={require("raw-loader!./snippets/promise-chain-2.snippet")}
+  code={require("!raw-loader!./snippets/promise-chain-2.snippet")}
   theme={nightOwl}
   lang="javascript"
   title="Extracting Reusability"
@@ -62,7 +62,7 @@ import ReplIt from "../../components/replit";
 
 ---
 <CodeSurfer
-  code={require("raw-loader!./snippets/promise-chain-4.snippet")}
+  code={require("!raw-loader!./snippets/promise-chain-4.snippet")}
   theme={nightOwl}
   lang="javascript"
   title="Can live in a shared location"
@@ -75,7 +75,7 @@ import ReplIt from "../../components/replit";
 />
 ---
 <CodeSurfer
-  code={require("raw-loader!./snippets/promise-chain-3.snippet")}
+  code={require("!raw-loader!./snippets/promise-chain-3.snippet")}
   theme={nightOwl}
   lang="javascript"
   title="Improved Reuse"

--- a/decks/promises/02-promise-errors.mdx
+++ b/decks/promises/02-promise-errors.mdx
@@ -36,7 +36,7 @@ getData().then(function onSuccess() {
 ---
 
 <CodeSurfer
-  code={require("raw-loader!./snippets/promise-errors-1.snippet")}
+  code={require("!raw-loader!./snippets/promise-errors-1.snippet")}
   theme={nightOwl}
   lang="javascript"
   title="Promise Errors"
@@ -94,7 +94,7 @@ getData().then(function onSuccess() {
 
 ---
 <CodeSurfer
-  code={require("raw-loader!./snippets/promise-errors-2.snippet")}
+  code={require("!raw-loader!./snippets/promise-errors-2.snippet")}
   theme={nightOwl}
   lang="javascript"
   title="Single error handler"
@@ -108,7 +108,7 @@ getData().then(function onSuccess() {
 ---
 
 <CodeSurfer
-  code={require("raw-loader!./snippets/promise-errors-3.snippet")}
+  code={require("!raw-loader!./snippets/promise-errors-3.snippet")}
   theme={nightOwl}
   lang="javascript"
   title="Catch and Release"
@@ -129,7 +129,7 @@ getData().then(function onSuccess() {
 
 ---
 <CodeSurfer
-  code={require("raw-loader!./snippets/promise-errors-4.snippet")}
+  code={require("!raw-loader!./snippets/promise-errors-4.snippet")}
   theme={nightOwl}
   lang="javascript"
   title="Graceful Errors"

--- a/decks/react/03-composition.mdx
+++ b/decks/react/03-composition.mdx
@@ -32,9 +32,8 @@ import { childrenOne } from './snippets/03-composition'
 ## Compare and Contrast...
 
 ---
-
 <CodeSurfer
-  code={require("raw-loader!./snippets/article-layout.snippet")}
+  code={require("!raw-loader!./snippets/article-layout.snippet")}
   theme={nightOwl}
   lang="javascript"
   title="ArticleLayout With Props"
@@ -46,11 +45,10 @@ import { childrenOne } from './snippets/03-composition'
     {}
   ]}
 />
-
 ---
 
 <CodeSurfer
-  code={require("raw-loader!./snippets/article-layout-composed.snippet")}
+  code={require("!raw-loader!./snippets/article-layout-composed.snippet")}
   theme={nightOwl}
   lang="javascript"
   title="ArticleLayout With Composition"

--- a/decks/template-literals/01-intro.mdx
+++ b/decks/template-literals/01-intro.mdx
@@ -23,7 +23,7 @@ import nightOwl from "prism-react-renderer/themes/nightOwl"
 
 ---
 <CodeSurfer
-  code={require("raw-loader!../../snippets/template-ex-1.snippet")}
+  code={require("!raw-loader!../../snippets/template-ex-1.snippet")}
   theme={nightOwl}
   lang="javascript"
   title="Previous String Concat"
@@ -37,7 +37,7 @@ import nightOwl from "prism-react-renderer/themes/nightOwl"
 
 ---
 <CodeSurfer
-  code={require("raw-loader!../../snippets/template-ex-2.snippet")}
+  code={require("!raw-loader!../../snippets/template-ex-2.snippet")}
   theme={nightOwl}
   lang="javascript"
   title="Template Literals"
@@ -50,7 +50,7 @@ import nightOwl from "prism-react-renderer/themes/nightOwl"
 />
 ---
 <CodeSurfer
-  code={require("raw-loader!../../snippets/template-ex-3.snippet")}
+  code={require("!raw-loader!../../snippets/template-ex-3.snippet")}
   theme={nightOwl}
   lang="javascript"
   title="Multiline and Expressions"

--- a/decks/variables/03-const.mdx
+++ b/decks/variables/03-const.mdx
@@ -10,7 +10,7 @@ import { CodeSurfer } from "mdx-deck-code-surfer"
 
 ---
 <CodeSurfer
-  code={require("raw-loader!../../snippets/const-example.snippet")}
+  code={require("!raw-loader!../../snippets/const-example.snippet")}
   lang="javascript"
   title="Const Overview"
   showNumbers

--- a/demo-advanced.mdx
+++ b/demo-advanced.mdx
@@ -44,7 +44,7 @@ Let's take a look at our `now.json` file...
 
 ---
 <CodeSurfer
-  code={require("raw-loader!./snippets/example-nowconfiguration.snippet")}
+  code={require("!raw-loader!./snippets/example-nowconfiguration.snippet")}
   title="ZEIT Now - now.json"
   showNumbers
   steps={[
@@ -69,7 +69,7 @@ Add a `now-build` script to `package.json` which
 
 ---
 <CodeSurfer
-  code={require("raw-loader!./snippets/example-packagejson.snippet")}
+  code={require("!raw-loader!./snippets/example-packagejson.snippet")}
   title="ZEIT Now - package.json"
   showNumbers
   steps={[


### PR DESCRIPTION
Seems like if we loaded something with

```js
code={require("!raw-loader!../../snippets/const-example.snippet")}
```

and in another spot

```
code={require("raw-loader!../../snippets/const-example.snippet")}
```

(Leading ! or not) - it would cause other things to be weird

changed them all to have leading `!`