### PR TITLE
Promise Deck Changes 

### DIFF
--- a/decks/promises/00-promises.mdx
+++ b/decks/promises/00-promises.mdx
@@ -9,25 +9,58 @@ import Code from 'mdx-code';
 
 ---
 
-## What we will cover
+## What We Will Cover
 
 * What are they?
 * Promises vs Callbacks 
-* Promises Return Promises
 * Chaining Promises
 * Handling Errors
 * Promise Patterns
 
 ---
-export default Code
 
-```javascript ES6 Promises
-let something = new Promise((resolve, reject)=> {
-    resolve('a value')
+## What Is a Promise?
+
+* Represent an eventual result of an asynchronous operation 
+* The result can be a successful completion, or a failure 
+
+---
+
+## What Is a Promise? 
+
+> Essentially, a promise is a returned object to which you attach callbacks, instead of passing callbacks into a function.
+
+[MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Using_promises)
+
+---
+
+## Constructing a Promise 
+
+* Syntax: `new Promise(executor)`
+* executor is a function that takes a resolve, and a reject. 
+
+```javascript
+let someValue = new Promise((resolve, reject)=> {
+  resolve('Hello World')
 });
 
-something.then(value=>{
-  console.log(value);
+someValue.then(result=>{
+  console.log(result);
+  return result;
+})
+```
+
+---
+export default Code
+
+```javascript Using Promises
+let someValue = new Promise((resolve, reject)=> {
+  resolve('Hello World')
+});
+
+someValue.then(result=>{
+  console.log(result);
+  return result;
 })
 ```
 
@@ -35,7 +68,9 @@ something.then(value=>{
 ## Promises vs Callbacks
 
 JavaScript is single threaded, so we can't really ever "wait" for a result of
-a task such as an HTTP request. Our baseline solution is callbacks:
+a task such as an HTTP request. 
+
+Our baseline solution is callbacks:
 
 ```javascript
   request(url, function(error, response) {
@@ -101,19 +136,18 @@ specify and dispatch the request in one place:</p>
   code={require("!raw-loader!../../snippets/promises-1.snippet")}
   theme={nightOwl}
   lang="javascript"
-  title="Fun with Promises"
+  title="Exploring Promises"
   showNumbers
   steps={[
     {}, // First step should be an overview of the snippet
     {lines: [1], notes: "Start the request"},
-    {range: [5,7], notes: "Handle the response in another location"},
-    {range: [11,12], notes: "Have multiple handlers"},
+    {range: [5,7], notes: "Handle the Response"},
+    {range: [11,12], notes: "Have Multiple Handlers"},
     {}
   ]}
 />
 
 ---
-
 export default FullScreenCode
 
 ### Promise Exercises - even and odd
@@ -127,57 +161,3 @@ export default FullScreenCode
 ### Promise Exercises - even and odd - solution
 
 <ReplIt src="https://repl.it/@e_schultz/Simple-Promise-Solution?lite=true"/>
-
----
-
-## Remember!
-
-<Appear>
-    Promises Return Promises
-</Appear>
-
----
-
-## Lets explore that a bit more ....
-
----
-
-A key point to remember: unless your promise library is buggy, `.then()` always returns a promise. Always.
-
-```javascript
-  p1 = getDataAsync(query);
-
-  p2 = p1.then(
-    results => transformData(results));
-```
-
-`p2` is now a promise regardless of what transformData() returned. Even if
-something fails.
-
----
-
-### Why does this matter?
-
-<ul style={{listStyle: 'none'}}>
-<Appear>
-    <li> Promises Can Be Chained</li>
-    <li> Forgetting This Leads to the Deferred Anti-pattern</li>
-</Appear>
-</ul>
-
----
-
-## The deferred anti-pattern
-
-* [Bluebird explanation](https://github.com/petkaantonov/bluebird/wiki/Promise-anti-patterns)
-* If a `thenable` Returns a Promise
-* We Don't Need to Construct a New Promise 
-
----
-
-export default FullScreenCode
-
-### Anti-Pattern Demo
-
-<ReplIt src="https://repl.it/@e_schultz/Promises-deferred-anti-pattern?lite=true"/>
-

--- a/decks/promises/01-promise-chain.mdx
+++ b/decks/promises/01-promise-chain.mdx
@@ -22,7 +22,7 @@ asyncData
 ```
 ---
 
-## Lets explore that a bit more ....
+## Let's explore that a bit more ....
 
 ---
 

--- a/decks/promises/01-promise-chain.mdx
+++ b/decks/promises/01-promise-chain.mdx
@@ -1,10 +1,97 @@
 import { Head, Appear, Image, withDeck } from 'mdx-deck'  // https://github.com/jxnblk/mdx-deck
 import { CodeSurfer } from "mdx-deck-code-surfer"
+import Code from 'mdx-code';
 import { FullScreenCode } from "mdx-deck/layouts";
 import nightOwl from "prism-react-renderer/themes/nightOwl"
 import ReplIt from "../../components/replit";
 
-## Promise Chaining
+# Promise Chains 
+
+---
+
+## Key Points
+
+* A Promise Will Always Return a Promise 
+* When Inside of a `.then` - the Result Will Be Wrapped in a Promise
+* This Allows Us to Chain Promises
+
+```javascript 
+asyncData
+  .then(doSomething)
+  .then(doSomethingElse)
+```
+---
+
+## Lets explore that a bit more ....
+
+---
+
+A key point to remember:  `.then()` always returns a promise. Always.
+
+```javascript
+  p1 = getDataAsync(query);
+  p2 = p1.then(results => transformData(results));
+```
+
+`p2` is now a promise regardless of what transformData() returned. 
+
+Even if something fails.
+
+---
+export default Code 
+
+```javascript If transformData does not return a Promise
+
+let transformData = arr => arr.map(item => item * 2);
+let p1 = Promise.resolve([1, 2, 3, 4, 5]);
+let p2 = p1
+  .then(results => {
+    // we do not need to turn it into a promise
+    return transformData(results);
+  });
+```
+---
+export default Code 
+
+```javascript If transformData returns a promise
+
+let transformData = arr => Promise.resolve(arr.map(item => item * 2));
+let p1 = Promise.resolve([1, 2, 3, 4, 5]);
+let p2 = p1
+  .then(results => {
+    return transformData(results);
+  });
+```
+---
+
+### Why does this matter?
+
+<ul style={{listStyle: 'none'}}>
+<Appear>
+    <li> Promises Can Be Chained</li>
+    <li> Forgetting This Leads to the Deferred Anti-pattern</li>
+</Appear>
+</ul>
+
+---
+
+## The deferred anti-pattern
+
+* [Bluebird explanation](https://github.com/petkaantonov/bluebird/wiki/Promise-anti-patterns)
+* If a `thenable` Returns a Promise
+* We Don't Need to Construct a New Promise 
+
+---
+
+export default FullScreenCode
+
+### Anti-Pattern Demo
+
+<ReplIt src="https://repl.it/@e_schultz/Promises-deferred-anti-pattern?lite=true"/>
+
+---
+
+## Promise Chain Recap
 
 - A `Promise` returns a `Promise`
 - Once inside of a `.then` - the return value is turned into a promise, if it isn't already
@@ -19,11 +106,11 @@ import ReplIt from "../../components/replit";
   showNumbers
   steps={[
     {}, // First step should be an overview of the snippet
-    {lines: [2], notes: "This returns a promise"},
-    {range: [6,8], notes: "Once inside a then - it wraps the result in a promise"},
-    {range: [9,11], notes: "Allowing us to chain operations together"},
-    {range: [13,21], notes: "Similar to the managers"},
-    {range: [17,18], notes: "But easy to add new features / requirements"},
+    {lines: [2], notes: "This Returns a Promise"},
+    {range: [6,8], notes: "Once Inside a .then - It Wraps the Result in a Promise"},
+    {range: [9,11], notes: "Allowing Us to Chain Operations Together"},
+    {range: [13,21], notes: "Similar to the Managers"},
+    {range: [17,18], notes: "But Easy to Add New Features / Requirements"},
     {}
   ]}
 />

--- a/decks/promises/02-promise-errors.mdx
+++ b/decks/promises/02-promise-errors.mdx
@@ -7,7 +7,8 @@ import ReplIt from "../../components/replit";
 ## Promise Error Handling 
 
 * doSomethingAsync().then(onSuccess,onError)
-* the `onError` will catch errors in `doSomethingAsync` not in `onSuccess`
+* the `onError` will catch errors in `doSomethingAsync` 
+* not in `onSuccess`
 
 ---
 
@@ -23,7 +24,7 @@ getData().then(function onSuccess() {
 
 ---
 
-## How Do Handle an Error If Something Breaks in `onSuccess`?
+## How To Handle an Error If Something Breaks in `onSuccess`?
 
 ```javascript
 getData().then(function onSuccess() {
@@ -63,7 +64,7 @@ getData().then(function onSuccess() {
         2: [15, 16, 17, 18, 19, 20, 21, 22, 23, 24],
        
       },
-      notes: "If this resolves"
+      notes: "If this resolves OR returns"
     },
     {
       tokens: { 
@@ -100,13 +101,12 @@ getData().then(function onSuccess() {
   title="Single Error Handler"
   showNumbers
   steps={[
-    { notes: "Let errors fall through" },
-    { lines: [5], notes: "Gets any errors that happen above" },
+    { notes: "Let Errors Fall Through" },
+    { lines: [5], notes: "Catches Any Errors That Happen Above" },
   ]}
 />
 
 ---
-
 <CodeSurfer
   code={require("!raw-loader!./snippets/promise-errors-3.snippet")}
   theme={nightOwl}
@@ -123,9 +123,9 @@ getData().then(function onSuccess() {
 />
 
 ---
-### When would you want to handle other than at the end?
+### When Would You Want to Handle an Error Earlier?
 
-#### If you have a fall-back value that can continue the chain
+#### If You Have a Fall-back Value That Can Continue the Chain
 
 ---
 <CodeSurfer
@@ -135,9 +135,9 @@ getData().then(function onSuccess() {
   title="Graceful Errors"
   showNumbers
   steps={[
-    { notes: "If you can gracefully recover" },
-    { lines: [3], notes: "Could return a cached value" },
-    { range: [5,6], notes: "And continue the chain with the value" },
+    { notes: "If You Can Gracefully Recover" },
+    { lines: [3], notes: "Could Return a Cached Value" },
+    { range: [5,6], notes: "And Continue the Chain with the Value" },
     {}
   ]}
 />
@@ -148,3 +148,15 @@ export default FullScreenCode
 ## Exploring Errors
 
 <ReplIt src="https://repl.it/@e_schultz/Promise-Error-Handling-start?lite=true"/>
+
+---
+
+## Promise Error Handler
+
+* Unless explicitly rejecting or throwing, returns are treated as a successful resolve
+
+---
+
+# Break / Q&A
+
+## Up Next: Promise Patterns

--- a/decks/promises/02-promise-errors.mdx
+++ b/decks/promises/02-promise-errors.mdx
@@ -43,21 +43,21 @@ getData().then(function onSuccess() {
   title="Promise Errors"
   showNumbers
   steps={[
-    { notes: "Lets look at how errors flow through" },
-    { lines: [2], notes: "Handles success or error of getData" },
+    { notes: `Let's Look at How Errors Flow Through` },
+    { lines: [2], notes: "Handles Success or Error of getData" },
     {
       tokens: {
         3: [15, 16, 17, 18, 19, 20, 21, 22, 23, 24],
         2: [4, 5, 6, 7, 8, 9, 10, 11, 12, 13]
       },
-      notes: "Handles error from the then above"
+      notes: "Handles Error from the `.then` Above"
     },
     {
       tokens: {
         4: [15, 16, 17, 18, 19, 20, 21, 22, 23, 24],
         3: [4, 5, 6, 7, 8, 9, 10, 11, 12, 13]
       },
-      notes: "Handles error from the successB above"
+      notes: "Handles Error from the successB Above"
     },
     {
       tokens: {

--- a/decks/promises/03-promise-patterns.mdx
+++ b/decks/promises/03-promise-patterns.mdx
@@ -6,6 +6,7 @@ import ReplIt from "../../components/replit";
 import  Code  from 'mdx-code';
 
 # Promise Patterns  
+
 ---
 
 ## Promise Patterns - Parallel
@@ -22,6 +23,7 @@ import  Code  from 'mdx-code';
 - Another Request Needs the Result of a Previous 
 
 ---
+
 ## Promise Parallel - Promise.all
 
 * Waits for All Promises to Resolve
@@ -38,7 +40,7 @@ Promise.all([promiseA, promiseB, promiseC]).then(results => {
 ```
 
 ---
-## Promise.all - can also use destructuring
+## Promise.all - Can Also Use Destructuring
 
 - Waits for All Promises to Resolve
 - Gets Passed into the Handler as an Array
@@ -60,6 +62,7 @@ Promise.all([promiseA, promiseB, promiseC]).then(
 ## API Consideration 
 
 <a href="https://js-ts-training.now.sh/" target="_blank">Simple API</a>
+
 ---
 
 ## Exercise Time: 
@@ -80,14 +83,14 @@ let expected = {
 ---
 export default FullScreenCode
 
-# Promise.all the things
+# Promise.all : Start
 
 <ReplIt src="https://repl.it/@e_schultz/Promise-Parallel-Start?lite=true"/>
 
 ---
 export default FullScreenCode
 
-# Promise.all the solution
+# Promise.all :  Solution
 
 <ReplIt src="https://repl.it/@e_schultz/Promise-Parallel-Solution?lite=true"/>
 
@@ -98,14 +101,23 @@ export default FullScreenCode
 </div>
 ```
 ---
-# Promise - waterfall 
+# Promise - Waterfall 
 
-* Same API as last time
-* Maybe the Platform list is massive - and we want to get it by id
-* Instead of returning all platforms
+* Same API as Last Time
+* Get Platform by Id, Instead of All Platforms 
 * Request a Game
 * Request the Platform for that Game
-* Display similar result.
+* Display same result with platformName in the result object:
+
+```js
+let expected = {
+    id: 3,
+    name: "Dragon Quest XI: Echoes of an Elusive Age",
+    platformId: 1,
+    platformName: "PS4"
+  }
+
+```
 
 ---
 export default FullScreenCode
@@ -122,52 +134,34 @@ export default FullScreenCode
 <ReplIt src="https://repl.it/@e_schultz/Promise-Waterfall-Solution?lite=true"/>
 
 ---
+
+# Flatten Nested Promises
+
+---
+export default FullScreenCode
+
 ## Flattening The Chain .... take 1
 
 <ReplIt src="https://repl.it/@e_schultz/Promise-Waterfall-Solution-Flat-Solution?lite=true"/>
 
 ---
+export default FullScreenCode
+
 ## Flattening The Chain .... take 2 
 
 <ReplIt src="https://repl.it/@e_schultz/Promise-Waterfall-Solution-Flat-Solution-Alt?lite=true"/>
 
 ---
 
-### Sequential Promises
-
-* When a Promise Does Not Rely on the Result of Another
-* Want to Run Sequentially Instead of in Parallel
-* Why? Maybe API rate limiting will complain if you fire off 500 at once.
-* Good for bulk operations where you may not care about the actual api response 
+# Advanced Promise Patterns 
 
 ---
 
-### Sequential Promises
+## Promisify Synchronous Values
 
-* Promise.all executes in Parallel 
-* No built in Sequential --- so lets build it.
-
----
-export default FullScreenCode
-
-### Sequential Promises - Example
-
-<ReplIt src="https://repl.it/@e_schultz/Sequential-Promises-example?lite=true"/>
-
----
-export default FullScreenCode
-
-### Step Series Promises - Example
-
-<ReplIt src="https://repl.it/@e_schultz/Step-Series-Promises-example-all-results?lite=true"/>
-
----
-
-### Promisify Synchronous Values
-
-* Sometimes you may want to turn a sync value into an async one
-* Possibly you have mock data you will replace with a real API later
-* Can also be used as a way to cache a value 
+* Turn a Sync Value into an Async One
+* Useful to Mock Data That Will Be Replaced with a Real Api Later
+* Can Also Be Used as a Way to Cache a Value 
 
 ---
 export default FullScreenCode
@@ -201,8 +195,8 @@ getGameData(4).then(n=>{
 
 ### Caching Async Data
 
-* Promises can be reused
-* If you store a promise, and return it again - you will get the previously resolved value
+* Promises Can Be Reused
+* If You Store a Promise, and Return It Again - You Will Get the Previously Resolved Value
 
 ---
 export default FullScreenCode
@@ -215,9 +209,9 @@ export default FullScreenCode
 
 ### Promise Exercise - Cache the API Response 
 
-* Check to see if a game has been requested yet
-* If so - return the cached value
-* If not - get the value and store it in the cache 
+* Check to See If a Game Has Been Requested Yet
+* If so - Return the Cached Value
+* If Not - Get the Value and Store It in the Cache 
 
 ---
 export default FullScreenCode
@@ -232,14 +226,14 @@ export default FullScreenCode
 
 ### Promise Cache - Solution
 
-<ReplIt src="https://repl.it/@e_schultz/Promise-Cache-Exercise-start?lite=true"/>
+<ReplIt src="https://repl.it/@e_schultz/Promise-Cache-Exercise-solution?lite=true"/>
 
 ---
 
 ### Promise Exercise - Bonus
 
-* Make a generic cache for any fetch request - regardless of Games, Platform, etc. 
-* How would you approach this?
+* Make a Generic Cache for Any Fetch Request - Regardless of Games, Platform, Etc.
+* How Would You Approach This?
 
 ---
 ### Promise Exercise - Bonus - Start 
@@ -249,11 +243,7 @@ export default FullScreenCode
 <ReplIt src="https://repl.it/@e_schultz/Promise-Cache-Exercise-Bonus-Start?lite=true"/>
 
 ---
-### Promise Exercise - Bonus - Solution
 
-## None yet - no peeking! 
+# Break / Q&A
 
 ---
-
-# Break / Q&A 
-

--- a/decks/promises/04-extra-promise-patterns.mdx
+++ b/decks/promises/04-extra-promise-patterns.mdx
@@ -1,0 +1,30 @@
+### Sequential Promises
+
+* When a Promise Does Not Rely on the Result of Another
+* Want to Run Sequentially Instead of in Parallel
+* Why? Maybe API rate limiting will complain if you fire off 500 at once.
+* Good for bulk operations where you may not care about the actual api response 
+
+---
+
+
+### Sequential Promises
+
+* Promise.all executes in Parallel 
+* No built in Sequential --- so lets build it.
+
+---
+export default FullScreenCode
+
+### Sequential Promises - Example
+
+<ReplIt src="https://repl.it/@e_schultz/Sequential-Promises-example?lite=true"/>
+
+---
+export default FullScreenCode
+
+### Step Series Promises - Example
+
+<ReplIt src="https://repl.it/@e_schultz/Step-Series-Promises-example-all-results?lite=true"/>
+
+---


### PR DESCRIPTION
Cleaned up Promise Intro - and moved some items from 00-promises.mdx to promise chain

## Promise Chain

- clarify how a promise always returns a promise, even if it calls a function that does not return a promise.

## Promise Error
- Tried to clarify wording that the onSuccess/error handles the promise above
- Better example how if 'onError' returns - it will be treated as a resolve unless you explicitly throw or reject
 - Tried to clean up wording around 'when would you want to catch early?'
 - Simpler exploring errors example
- trying to break in some break / q&a reminders into the slides instead of just powering through

## Promise Patterns

- Mostly cleaned up the wording
- Moved the 'step sequence' to the extra-promise-patterns slide (may not bother getting around to it - but didn't want to drop content from repo yet)
- Simplify wording on some instruction steps